### PR TITLE
Responsive fixes for Calendar, About, Host and Speak pages on mobile

### DIFF
--- a/app/(how-we-work)/host/page.tsx
+++ b/app/(how-we-work)/host/page.tsx
@@ -106,8 +106,8 @@ export default function HostPage() {
 }
 
 const Styles = {
-  section: "px-16 py-12 pb-20",
-  sectionHeader: "text-6xl mb-12",
+  section: "px-4 xs:px-16 py-12 pb-20",
+  sectionHeader: "text-4xl xs:text-6xl mb-12 break-words",
   subHeader: "text-2xl/loose",
   logisticsItem: "mb-8",
   itemHeader: "text-xl/loose font-light",

--- a/app/(how-we-work)/speak/page.tsx
+++ b/app/(how-we-work)/speak/page.tsx
@@ -103,8 +103,8 @@ export default function SpeakPage() {
 }
 
 const Styles = {
-  section: "px-16 py-12 pb-20",
-  sectionHeader: "text-6xl mb-12",
+  section: "px-4 xs:px-16 py-12 pb-20",
+  sectionHeader: "text-4xl xs:text-6xl mb-12 break-words",
   subHeader: "text-2xl/loose",
   logisticsItem: "mb-8",
   itemHeader: "text-xl/loose font-light",

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -20,7 +20,7 @@ export default function CalendarPage() {
         <div className="flex justify-center w-full">
           <iframe
             src="https://lu.ma/embed/calendar/cal-ZopuHimRKxPa5U0/events?lt=light"
-            className="w-full md:w-3/4 h-[600px] md:h-[900px]"
+            className="w-full md:w-3/4 h-[1200px] sm:h-[1000px] md:h-[900px]"
             style={{
               display: "block",
               overflow: "hidden",

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -16,13 +16,7 @@ export default function CalendarPage() {
           </p>
         </div>
       </section>
-      <section
-        className={twMerge(
-          Styles.section,
-          "flex flex-col lg:flex-row lg:gap-8",
-          "bg-[#f7f8f9]"
-        )}
-      >
+      <section className="px-0 py-12 md:py-20 flex flex-col lg:flex-row lg:gap-8 bg-[#f7f8f9]">
         <div className="flex justify-center w-full">
           <iframe
             src="https://lu.ma/embed/calendar/cal-ZopuHimRKxPa5U0/events?lt=light"

--- a/app/styles/shared-styles.tsx
+++ b/app/styles/shared-styles.tsx
@@ -16,8 +16,8 @@ export const SharedStyles = {
     "disabled:cursor-not-allowed",
     "disabled:opacity-50"
   ),
-  section: "px-16 py-12 pb-20",
-  sectionHeader: "text-6xl mb-12",
+  section: "px-4 xs:px-16 py-12 pb-20",
+  sectionHeader: "text-4xl xs:text-6xl mb-12 break-words",
   subHeader: "text-2xl/loose",
   logisticsItem: "mb-8",
   itemHeader: "text-xl/loose font-light",


### PR DESCRIPTION
- Reduce section heading sizes on mobile
- Remove horizontal padding around Luma iframe on Calendar page
- Adjust height of Luma iframe on mobile and tablet to prevent scrollbars

**Before/After Screenshots**

### Calendar
<img width="452" height="1777" alt="image" src="https://github.com/user-attachments/assets/7f91078c-09e9-4911-8213-5c531ac9aae2" />
  
<img width="439" height="1688" alt="image" src="https://github.com/user-attachments/assets/9eadd361-e74a-4256-9bff-52599d7ff5c1" />

### About
<img width="440" height="1145" alt="image" src="https://github.com/user-attachments/assets/514e03cf-429e-44de-b40c-a9f2ca801b47" />
  
<img width="442" height="972" alt="image" src="https://github.com/user-attachments/assets/88fea3ce-8c29-4f7c-8de7-56b2c528b6d1" />

### Host Us
<img width="439" height="1012" alt="image" src="https://github.com/user-attachments/assets/b491ecf8-b783-48d5-a99f-4e1364ddc074" />
  
<img width="439" height="964" alt="image" src="https://github.com/user-attachments/assets/5970731f-7efa-43d8-9119-c3bb5182667f" />

### Be A Speaker
<img width="443" height="1060" alt="image" src="https://github.com/user-attachments/assets/c7a6813e-21e6-4ce5-9366-6848a20b71f5" />
  
<img width="436" height="957" alt="image" src="https://github.com/user-attachments/assets/65db3eca-9afa-4772-87f1-4917aca50d6a" />


